### PR TITLE
Add multi-agent task runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
 # aoa
-army of agents
+
+Army of Agents (AOA) is a simple tool for dispatching multiple Codex
+agents to work on a list of tasks in parallel.  The CLI is written in
+TypeScript and coordinates the agents so they do not modify the same
+workspace concurrently.
+
+## Design Plan
+
+1. **Project setup**
+   - Node/TypeScript project using `bun` for running scripts.
+   - The CLI entry point is `src/index.ts`.
+
+2. **Task description file**
+   - Tasks are stored in a JSON file (see `examples/tasks.json`).
+   - Each entry is a string prompt that will be forwarded to a Codex
+     agent.
+
+3. **Starting a job**
+   - Run `bun run aoa start <tasks.json> -n <agents>` to start a job.
+   - The number of agents defaults to `1` when not specified.
+
+4. **Workspace isolation**
+   - Every agent works in its own Git worktree under `.worktrees/agent-X`.
+   - Worktrees are created from the current branch so changes do not
+     conflict.
+
+5. **Agent execution**
+   - Each agent receives a task, runs `codex` in its worktree and waits for it to finish.
+   - When all tasks are processed, worktrees are merged back sequentially.
+
+6. **Simple locking**
+   - Only one merge occurs at a time to prevent conflicts.
+   - Merges use fast-forward or create a new commit if needed.
+
+7. **Extending the system**
+   - Add more CLI commands (e.g. `status`, `stop`).
+   - Implement smarter task distribution or support for different prompts per agent.
+
+## Usage
+
+1. Install dependencies:
+
+```bash
+bun install
+```
+
+2. Create a JSON file describing tasks.  Example:
+
+```json
+[
+  "Add logging to the project",
+  "Write unit tests for the CLI"
+]
+```
+
+3. Start agents:
+
+```bash
+bun run aoa start tasks.json -n 2
+```
+
+This will spawn two Codex agents working in parallel on the listed tasks.

--- a/examples/tasks.json
+++ b/examples/tasks.json
@@ -1,0 +1,4 @@
+[
+  "Example task 1",
+  "Example task 2"
+]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "module": "index.ts",
   "type": "module",
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "@types/node": "^18.0.0"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,67 @@
-// entry point
+#!/usr/bin/env bun
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+function exec(cmd: string, opts: { cwd?: string } = {}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, { shell: true, stdio: 'inherit', ...opts });
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} exited with code ${code}`));
+    });
+  });
+}
+
+async function runTask(task: string, id: number) {
+  const base = path.resolve('.worktrees');
+  const dir = path.join(base, `agent-${id}`);
+  await fs.promises.mkdir(base, { recursive: true });
+  // create isolated worktree
+  await exec(`git worktree add ${dir}`);
+  try {
+    // run codex cli with the task prompt
+    await exec(`codex "${task}"`, { cwd: dir });
+    // commit changes inside worktree
+    await exec('git add -A', { cwd: dir });
+    await exec(`git commit -m "agent-${id}: ${task}"`, { cwd: dir });
+    // merge back to main workspace
+    await exec(`git merge --ff-only ${path.basename(dir)}`, { cwd: '.' });
+  } finally {
+    await exec(`git worktree remove ${dir}`);
+  }
+}
+
+async function runAgents(tasks: string[], count: number) {
+  let next = 0;
+  async function worker(id: number) {
+    while (true) {
+      const index = next++;
+      if (index >= tasks.length) break;
+      const task = tasks[index];
+      console.log(`Agent ${id} running task: ${task}`);
+      await runTask(task, id);
+    }
+  }
+  await Promise.all(Array.from({ length: count }, (_, i) => worker(i)));
+}
+
+async function main() {
+  const [, , cmd, file, ...rest] = process.argv;
+  if (cmd !== 'start' || !file) {
+    console.error('Usage: aoa start <tasks.json> [-n agents]');
+    process.exit(1);
+  }
+  let agents = 1;
+  const n = rest.indexOf('-n');
+  if (n !== -1 && rest[n + 1]) {
+    agents = parseInt(rest[n + 1], 10);
+  }
+  const tasks = JSON.parse(fs.readFileSync(file, 'utf8')) as string[];
+  await runAgents(tasks, agents);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     // Enable latest features
     "lib": ["ESNext", "DOM"],
+    "types": ["node"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- outline the plan for coordinating agents
- implement a simple TypeScript CLI for dispatching codex agents in parallel
- provide example task list
- configure TypeScript for node modules

## Testing
- `bun build src/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_685a1454a708832daec41a76dffb9d7f