### PR TITLE
Add basic unit tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,9 @@
 import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-function exec(cmd: string, opts: { cwd?: string } = {}): Promise<void> {
+export async function exec(cmd: string, opts: { cwd?: string } = {}): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(cmd, { shell: true, stdio: 'inherit', ...opts });
     child.on('close', (code) => {
@@ -13,7 +14,7 @@ function exec(cmd: string, opts: { cwd?: string } = {}): Promise<void> {
   });
 }
 
-async function runTask(task: string, id: number) {
+export async function runTask(task: string, id: number) {
   const base = path.resolve('.worktrees');
   const dir = path.join(base, `agent-${id}`);
   await fs.promises.mkdir(base, { recursive: true });
@@ -32,7 +33,7 @@ async function runTask(task: string, id: number) {
   }
 }
 
-async function runAgents(tasks: string[], count: number) {
+export async function runAgents(tasks: string[], count: number) {
   let next = 0;
   async function worker(id: number) {
     while (true) {
@@ -46,7 +47,7 @@ async function runAgents(tasks: string[], count: number) {
   await Promise.all(Array.from({ length: count }, (_, i) => worker(i)));
 }
 
-async function main() {
+export async function main() {
   const [, , cmd, file, ...rest] = process.argv;
   if (cmd !== 'start' || !file) {
     console.error('Usage: aoa start <tasks.json> [-n agents]');
@@ -61,7 +62,9 @@ async function main() {
   await runAgents(tasks, agents);
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -1,0 +1,10 @@
+import { exec } from '../src/index';
+import { expect, test } from 'bun:test';
+
+test('exec resolves on success', async () => {
+  await exec('echo hello');
+});
+
+test('exec rejects on failure', async () => {
+  await expect(exec('false')).rejects.toThrow();
+});

--- a/test/runAgents.test.ts
+++ b/test/runAgents.test.ts
@@ -1,0 +1,18 @@
+import * as mod from '../src/index';
+import { expect, test, vi } from 'bun:test';
+
+test('runAgents distributes tasks across workers', async () => {
+  const tasks: string[] = [];
+  const runTask = vi.fn(async (task: string) => {
+    tasks.push(task);
+  });
+
+  const spy = vi.spyOn(mod, 'runTask').mockImplementation(runTask);
+
+  await mod.runAgents(['t1', 't2', 't3'], 2);
+
+  spy.mockRestore();
+
+  expect(runTask).toHaveBeenCalledTimes(3);
+  expect(tasks).toEqual(['t1', 't2', 't3']);
+});


### PR DESCRIPTION
## Summary
- expose internal functions from the CLI entry
- execute main only when run directly
- add unit tests for `exec` and `runAgents`

## Testing
- `bun test`
- `bun run src/index.ts start examples/tasks.json -n 1` *(fails: `codex` command missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a1a328bdc832dba7d78d028e97da7